### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/src/simpleguardhome/main.py
+++ b/src/simpleguardhome/main.py
@@ -49,7 +49,7 @@ async def health_check() -> Dict:
         logger.error(f"Health check failed: {str(e)}")
         return {
             "status": "error",
-            "error": str(e)
+            "error": "An internal error has occurred. Please try again later."
         }
 
 @app.exception_handler(AdGuardError)


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/simpleguardhome/security/code-scanning/1](https://github.com/pacnpal/simpleguardhome/security/code-scanning/1)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to return a generic error message while logging the detailed error message.

- Modify the exception handling block in the `health_check` function to return a generic error message.
- Ensure that the detailed error message is logged using the existing logger.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
