### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/simpleguardhome/templates/index.html
+++ b/src/simpleguardhome/templates/index.html
@@ -5,10 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SimpleGuardHome</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.4/purify.min.js"></script>
     <script>
         async function checkDomain(event) {
             event.preventDefault();
-            const domain = document.getElementById('domain').value;
+            const domain = DOMPurify.sanitize(document.getElementById('domain').value);
             const resultDiv = document.getElementById('result');
             const unblockDiv = document.getElementById('unblock-action');
             const submitBtn = document.getElementById('submit-btn');


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/simpleguardhome/security/code-scanning/3](https://github.com/pacnpal/simpleguardhome/security/code-scanning/3)

To fix the problem, we need to ensure that any user input is properly sanitized or escaped before being inserted into the DOM as HTML. This can be achieved by using a library like DOMPurify to sanitize the input, or by manually escaping any HTML special characters.

The best way to fix this issue without changing existing functionality is to use DOMPurify to sanitize the `domain` variable before using it in the HTML content. This ensures that any potentially malicious scripts are removed from the input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
